### PR TITLE
protocols : Pigeon moved to GitHub

### DIFF
--- a/protocols.html
+++ b/protocols.html
@@ -53,7 +53,7 @@
 
 <ul>
     <li><a href="https://github.com/earthstar-project/earthstar">EarthStar</a></li>
-    <li><a href="https://tildegit.org/PigeonProtocolConsortium/protocol_spec">Pigeon Protocol</a></li>
+    <li><a href="https://github.com/PigeonProtocolConsortium/pigeon-spec">Pigeon Protocol</a></li>
 </ul>
 
 <p>PRs for more protocols are welcome.</p>


### PR DESCRIPTION
As per the description on https://tildegit.org/PigeonProtocolConsortium/Protocol-Spec to date, the Pigeon Protocol have moved to GitHub at https://github.com/PigeonProtocolConsortium/pigeon-spec

Here we update the old link with the new target.