### PR TITLE
Fix blog links in explore.md

### DIFF
--- a/explore.md
+++ b/explore.md
@@ -17,8 +17,8 @@ Feel free to [submit a pull request](https://github.com/AgregoreWeb/website/) on
 
 ### Blogs / Homepages
 
-- [Mauve's Blog](://blog.mauve.moe/)
-- [Hypha Worker Coop](://hypha.coop)
+- [Mauve's Blog](//blog.mauve.moe)
+- [Hypha Worker Coop](//hypha.coop)
 
 ### Magazines
 


### PR DESCRIPTION
Links to Mauve's Blog and Hypha Worker Coop have an erroneous initial `:` in the link, causing (for example) Mauve's Blog link to be `https://agregore.mauve.moe/://hypha.coop` when clicked from `https://agregore.mauve.moe/`.