### PR TITLE
Fix incorrect URL for tutorial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ Documentation for P2P protocol handlers that are supported by Agregore. A great 
 - [Directory Uploader](./tutorials/ipfs-dir-upload/)
 - [P2Pad Code editor](./tutorials/p2pad-code-editor/)
 - [Adding a 3rd-party dependency](./tutorials/ipfs-3rd-party-dep/)
-- [Building an IPFS gallery](./tutorial/ipfs-gallery/)
+- [Building an IPFS gallery](./tutorials/ipfs-gallery/)
 - [DLinktree Builder](./tutorials/dlinktree-builder)
 
 ---


### PR DESCRIPTION
There was a typo in the URL