### PR TITLE
Fix-p2pad-styles

### DIFF
--- a/docs/examples/p2pad/codeEditor.js
+++ b/docs/examples/p2pad/codeEditor.js
@@ -7,7 +7,7 @@ import { $, loadingSpinner, backdrop, iframe } from './common.js'; // Import com
 
 // Import CSS from Agregore theme to use in the iframe preview
 export let basicCSS = `
-@import url("agregore://theme/vars.css");
+@import url("agregore://theme/style.css");
             body {
                 font-size: 1.2rem;
                 margin: 0;

--- a/docs/examples/p2pad/codeEditor.js
+++ b/docs/examples/p2pad/codeEditor.js
@@ -8,7 +8,7 @@ import { $, loadingSpinner, backdrop, iframe } from './common.js'; // Import com
 // Import CSS from Agregore theme to use in the iframe preview
 export let basicCSS = `
 @import url("agregore://theme/vars.css");
-            body, * {
+            body {
                 font-size: 1.2rem;
                 margin: 0;
                 padding: 0;


### PR DESCRIPTION
- Removes the universal CSS selector (*) to fix styling conflicts
- Loads style.css instead of vars.css